### PR TITLE
Omitted API Key

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 /*---------------------------------------API--------------------------------------------*/
 
 const api = {
-    key: "bbeac64cfcccb55a846070e17439f18f",
+    key: "Your_API_Key",
     base: "https://api.openweathermap.org/data/2.5/weather?", 
 }
 


### PR DESCRIPTION
Your API key was left in the source code, since this is for a workshop I thought it best to just replace it with Your_API_Key